### PR TITLE
full_url in helpers is using the port of the connection to overwrite things like the callback_url

### DIFF
--- a/lib/ueberauth/strategies/helpers.ex
+++ b/lib/ueberauth/strategies/helpers.ex
@@ -125,12 +125,15 @@ defmodule Ueberauth.Strategy.Helpers do
     %URI{
       host: conn.host,
       scheme: to_string(conn.scheme),
-      port: conn.port,
+      port: normalize_port(conn.scheme, conn.port),
       path: path,
       query: URI.encode_query(opts)
     }
     |> to_string
   end
+
+  defp normalize_port(:https, 80), do: 443
+  defp normalize_port(_, port), do: port
 
   @doc false
   defp map_errors(nil), do: []

--- a/lib/ueberauth/strategies/helpers.ex
+++ b/lib/ueberauth/strategies/helpers.ex
@@ -127,13 +127,16 @@ defmodule Ueberauth.Strategy.Helpers do
       scheme: to_string(conn.scheme),
       port: normalize_port(conn.scheme, conn.port),
       path: path,
-      query: URI.encode_query(opts)
+      query: encode_query(opts)
     }
     |> to_string
   end
 
   defp normalize_port(:https, 80), do: 443
   defp normalize_port(_, port), do: port
+
+  defp encode_query([]), do: nil
+  defp encode_query(opts), do: URI.encode_query(opts)
 
   @doc false
   defp map_errors(nil), do: []

--- a/test/ueberauth_test.exs
+++ b/test/ueberauth_test.exs
@@ -110,6 +110,13 @@ defmodule UeberauthTest do
     assert auth.strategy == Support.SimpleCallback
   end
 
+  test "callback_url port" do
+    conn = %{conn(:get, "/") | scheme: :https, port: 80}
+    conn = put_private(conn, :ueberauth_request_options, [callback_path: "/auth/provider/callback"])
+    assert Ueberauth.Strategy.Helpers.callback_url(conn) ==
+      "https://www.example.com/auth/provider/callback"
+  end
+
   defp assert_standard_info(auth) do
     info = auth.info
 

--- a/test/ueberauth_test.exs
+++ b/test/ueberauth_test.exs
@@ -28,8 +28,8 @@ defmodule UeberauthTest do
     assert extra.raw_info.request_path == "/auth/simple"
     assert extra.raw_info.callback_path == "/auth/simple/callback"
 
-    assert extra.raw_info.request_url == "http://www.example.com/auth/simple?"
-    assert extra.raw_info.callback_url == "http://www.example.com/auth/simple/callback?"
+    assert extra.raw_info.request_url == "http://www.example.com/auth/simple"
+    assert extra.raw_info.callback_url == "http://www.example.com/auth/simple/callback"
   end
 
   test "redirecting a request phase" do


### PR DESCRIPTION
On heroku we're getting a forwarded port of 443 -> 80 which makes the callback port incorrect (it's inserting a port 80 into a https url)