### PR TITLE
Add oauth2 to applications list in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ See `Ueberauth.Strategy` for more information on constructing the Ueberauth.Auth
 def application do
   # Add the application to your list of applications.
   # This will ensure that it will be included in a release.
-  [applications: [:logger, :ueberauth]]
+  [applications: [:logger, :oauth2, :ueberauth]]
 end
 
 defp deps do


### PR DESCRIPTION
Adds `:oauth2` to the applications list in the README example. 

When trying the google strategy, I kept getting hackney errors. After a few days of beating my head against it, I noticed that the example app [adds `:oauth2` to the applications list](https://github.com/ueberauth/ueberauth_example/blob/master/mix.exs#L22). I figure some explanation could save the next person :smiley_cat: .

If I'm misunderstanding this or if this is specific to the google strategy, my apologies. 