### PR TITLE
Allow selecting some providers in the plug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.2.1
+
+* Add the ability to select which providers to use on a per-plug basis
+
 # 0.2.0
 
 * Remove the Ueberauth.plug function in favour of making Ueberauth a plug


### PR DESCRIPTION
This PR allows for selecting _some_ of the providers on a per-plug call basis.

```elixir
plug Ueberauth # all providers - existing behaviour unchanged
```

VS

```elixir
plug Ueberauth, providers: [:identity, :slack], base_path: "/admin/auth"
```