### PR TITLE
support x-forwarded-proto (behind an https proxy)

### DIFF
--- a/lib/ueberauth/strategies/helpers.ex
+++ b/lib/ueberauth/strategies/helpers.ex
@@ -137,15 +137,33 @@ defmodule Ueberauth.Strategy.Helpers do
   end
 
   defp full_url(conn, path, opts \\ []) do
+    scheme = conn
+    |> forwarded_proto
+    |> coalesce(conn.scheme)
+    |> normalize_scheme
+
     %URI{
       host: conn.host,
-      scheme: to_string(conn.scheme),
-      port: normalize_port(conn.scheme, conn.port),
+      port: normalize_port(scheme, conn.port),
       path: path,
-      query: encode_query(opts)
+      query: encode_query(opts),
+      scheme: to_string(scheme),
     }
     |> to_string
   end
+
+  defp forwarded_proto(conn) do
+    conn
+    |> Plug.Conn.get_req_header("x-forwarded-proto")
+    |> List.first
+  end
+
+  defp normalize_scheme("https"), do: :https
+  defp normalize_scheme("http"), do: :http
+  defp normalize_scheme(scheme), do: scheme
+
+  defp coalesce(nil, second), do: second
+  defp coalesce(first, _), do: first
 
   defp normalize_port(:https, 80), do: 443
   defp normalize_port(_, port), do: port

--- a/test/ueberauth_test.exs
+++ b/test/ueberauth_test.exs
@@ -117,6 +117,13 @@ defmodule UeberauthTest do
       "https://www.example.com/auth/provider/callback"
   end
 
+  test "callback_url forwarded protocol" do
+    conn = %{conn(:get, "/") |> put_req_header("x-forwarded-proto", "https") | scheme: :http, port: 80}
+    conn = put_private(conn, :ueberauth_request_options, [callback_path: "/auth/provider/callback"])
+    assert Ueberauth.Strategy.Helpers.callback_url(conn) ==
+      "https://www.example.com/auth/provider/callback"
+  end
+
   defp assert_standard_info(auth) do
     info = auth.info
 


### PR DESCRIPTION
This change makes `callback_url` respect the `x-forwarded-proto` header if it exists. This ensures that https urls will be generated when the app is running on an http server behind and https proxy.