### PR TITLE
Fix compiler warning

### DIFF
--- a/lib/ueberauth.ex
+++ b/lib/ueberauth.ex
@@ -178,13 +178,14 @@ defmodule Ueberauth do
     {all_providers, _opts} = Keyword.pop(opts, :providers)
     all_providers = Enum.into(all_providers, %{})
 
-    if provider_list == :all do
-      providers = all_providers
+    providers = if provider_list == :all do
+      all_providers
     else
-      {providers, _} = Map.split(all_providers, provider_list)
+      Map.split(all_providers, provider_list)
+      |> elem(0)
     end
 
-    Enum.reduce providers, %{}, fn {name, {module, opts}} = strategy, acc ->
+    Enum.reduce providers, %{}, fn {_name, {module, opts}} = strategy, acc ->
       request_path = request_path(base_path, strategy)
       callback_path = callback_path(base_path, strategy)
       callback_methods = callback_methods(opts)

--- a/lib/ueberauth/strategies/helpers.ex
+++ b/lib/ueberauth/strategies/helpers.ex
@@ -136,7 +136,7 @@ defmodule Ueberauth.Strategy.Helpers do
     if opts, do: opts[key], else: nil
   end
 
-  defp full_url(conn, path, opts \\ []) do
+  defp full_url(conn, path, opts) do
     scheme = conn
     |> forwarded_proto
     |> coalesce(conn.scheme)


### PR DESCRIPTION
Following three warning is issued in Elixir v1.2.5.

```
lib/ueberauth.ex:187: warning: the variable "providers" is unsafe as it has been defined in a conditional clause, as part of a case/cond/receive/if/&&/||. Please rewrite the clauses so the value is explicitly returned. For example:

    case int do
      1 -> atom = :one
      2 -> atom = :two
    end

Can be rewritten as:

    atom =
      case int do
        1 -> :one
        2 -> :two
      end
```

```
lib/ueberauth.ex:187: warning: variable name is unused
```

```
lib/ueberauth/strategies/helpers.ex:139: warning: default arguments in full_url/3 are never used
```