### PR TITLE
Intercept requests with and without a trailing slash

### DIFF
--- a/lib/ueberauth.ex
+++ b/lib/ueberauth.ex
@@ -201,7 +201,7 @@ defmodule Ueberauth do
 
   @doc false
   def call(%{request_path: request_path} = conn, opts) do
-    if strategy = Map.get(opts, request_path) do
+    if strategy = Map.get(opts, String.replace_trailing(request_path, "/", "")) do
       run!(conn, strategy)
     else
       conn
@@ -235,7 +235,7 @@ defmodule Ueberauth do
 
   defp request_path(base_path, {name, {_, opts}}) do
     default_path = Path.join(["/", base_path, to_string(name)])
-    Keyword.get(opts, :request_path, default_path)
+    String.replace_trailing(Keyword.get(opts, :request_path, default_path), "/", "")
   end
 
   defp callback_path(base_path, {name, {_, opts}}) do

--- a/test/ueberauth_test.exs
+++ b/test/ueberauth_test.exs
@@ -32,8 +32,13 @@ defmodule UeberauthTest do
     assert extra.raw_info.callback_url == "http://www.example.com/auth/simple/callback"
   end
 
-  test "redirecting a request phase" do
+  test "redirecting a request phase without trailing slash" do
     conn = conn(:get, "/auth/redirector") |> SpecRouter.call(@opts)
+    assert get_resp_header(conn, "location") == ["https://redirectme.example.com/foo"]
+  end
+
+  test "redirecting a request phase with trailing slash" do
+    conn = conn(:get, "/auth/redirector/") |> SpecRouter.call(@opts)
     assert get_resp_header(conn, "location") == ["https://redirectme.example.com/foo"]
   end
 


### PR DESCRIPTION
This is my attempt at solving the trailing slash issue, raised in issue #27.

It uses the `String.replace_trailing/3` function on the `:request_path` option, as well as stripping it from the incoming request, to make the strategy selection insensitive to trailing slashes.