### PR TITLE
Allow to add extra params to callback_url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 erl_crash.dump
 *.ez
 /doc
+/.idea

--- a/lib/ueberauth.ex
+++ b/lib/ueberauth.ex
@@ -190,9 +190,10 @@ defmodule Ueberauth do
       callback_path = callback_path(base_path, strategy)
       callback_methods = callback_methods(opts)
       callback_url = Keyword.get(opts, :callback_url)
+      callback_params = Keyword.get(opts, :callback_params)
 
-      request_opts = strategy_opts(strategy, request_path, callback_path, callback_methods, callback_url)
-      callback_opts = strategy_opts(strategy, request_path, callback_path, callback_methods, callback_url)
+      request_opts = strategy_opts(strategy, request_path, callback_path, callback_methods, callback_url, callback_params)
+      callback_opts = strategy_opts(strategy, request_path, callback_path, callback_methods, callback_url, callback_params)
 
       acc
       |> Map.put(request_path, {module, :run_request, request_opts})
@@ -225,14 +226,15 @@ defmodule Ueberauth do
     end
   end
 
-  defp strategy_opts({name, {module, opts}}, req_path, cb_path, cb_meths, cb_url) do
+  defp strategy_opts({name, {module, opts}}, req_path, cb_path, cb_meths, cb_url, cb_params) do
     %{strategy_name: name,
       strategy: module,
       callback_path: cb_path,
       request_path: req_path,
       callback_methods: cb_meths,
       options: opts,
-      callback_url: cb_url}
+      callback_url: cb_url,
+      callback_params: cb_params}
   end
 
   defp request_path(base_path, {name, {_, opts}}) do

--- a/lib/ueberauth/strategies/helpers.ex
+++ b/lib/ueberauth/strategies/helpers.ex
@@ -58,10 +58,8 @@ defmodule Ueberauth.Strategy.Helpers do
 
   @spec callback_url(Plug.Conn.t) :: String.t
   def callback_url(conn, opts \\ []) do
-    opts = callback_params(conn, opts)
-
     from_private(conn, :callback_url) ||
-    full_url(conn, callback_path(conn), opts)
+    full_url(conn, callback_path(conn),  callback_params(conn, opts))
   end
 
   @doc """

--- a/lib/ueberauth/strategies/helpers.ex
+++ b/lib/ueberauth/strategies/helpers.ex
@@ -58,8 +58,25 @@ defmodule Ueberauth.Strategy.Helpers do
 
   @spec callback_url(Plug.Conn.t) :: String.t
   def callback_url(conn, opts \\ []) do
+    opts = callback_params(conn, opts)
+
     from_private(conn, :callback_url) ||
     full_url(conn, callback_path(conn), opts)
+  end
+
+  @doc """
+  Build params for callback
+
+  This method will filter conn.params with whitelisted params from :callback_params settings
+  """
+  @spec callback_params(Plug.Conn.t) :: list(String.t)
+  def callback_params(conn, opts \\ []) do
+    callback_params = from_private(conn, :callback_params) || []
+    callback_params = callback_params
+      |> Enum.map(fn(k) -> {String.to_atom(k), conn.params[k]} end)
+      |> Enum.filter(fn {_, v} -> v != nil end)
+      |> Enum.filter(fn {k, _} -> k != "provider" end)
+    Keyword.merge(opts, callback_params)
   end
 
   @doc """

--- a/test/ueberauth_test.exs
+++ b/test/ueberauth_test.exs
@@ -14,7 +14,8 @@ defmodule UeberauthTest do
   end
 
   test "simple callback phase" do
-    conn = conn(:get, "/auth/simple/callback")
+    conn = :get
+      |> conn("/auth/simple/callback")
       |> SpecRouter.call(@opts)
     auth = conn.assigns.ueberauth_auth
 
@@ -121,6 +122,13 @@ defmodule UeberauthTest do
     conn = put_private(conn, :ueberauth_request_options, [callback_path: "/auth/provider/callback"])
     conn =  %{conn | params: %{}}
 
+    assert Ueberauth.Strategy.Helpers.callback_url(conn) ==
+      "https://www.example.com/auth/provider/callback"
+  end
+
+  test "callback_url forwarded protocol" do
+    conn = %{conn(:get, "/") |> put_req_header("x-forwarded-proto", "https") | scheme: :http, port: 80}
+    conn = put_private(conn, :ueberauth_request_options, [callback_path: "/auth/provider/callback"])
     assert Ueberauth.Strategy.Helpers.callback_url(conn) ==
       "https://www.example.com/auth/provider/callback"
   end

--- a/test/ueberauth_test.exs
+++ b/test/ueberauth_test.exs
@@ -14,7 +14,8 @@ defmodule UeberauthTest do
   end
 
   test "simple callback phase" do
-    conn = conn(:get, "/auth/simple/callback") |> SpecRouter.call(@opts)
+    conn = conn(:get, "/auth/simple/callback")
+      |> SpecRouter.call(@opts)
     auth = conn.assigns.ueberauth_auth
 
     assert auth.uid == "Elixir.Support.SimpleCallback-uid"
@@ -118,15 +119,18 @@ defmodule UeberauthTest do
   test "callback_url port" do
     conn = %{conn(:get, "/") | scheme: :https, port: 80}
     conn = put_private(conn, :ueberauth_request_options, [callback_path: "/auth/provider/callback"])
+    conn =  %{conn | params: %{}}
+
     assert Ueberauth.Strategy.Helpers.callback_url(conn) ==
       "https://www.example.com/auth/provider/callback"
   end
 
-  test "callback_url forwarded protocol" do
-    conn = %{conn(:get, "/") |> put_req_header("x-forwarded-proto", "https") | scheme: :http, port: 80}
-    conn = put_private(conn, :ueberauth_request_options, [callback_path: "/auth/provider/callback"])
+  test "callback_url has extra params" do
+    conn = conn(:get, "/")
+    conn = put_private(conn, :ueberauth_request_options, [callback_params: ["type"]])
+    conn =  %{conn | params: %{"type" => "user", "param_2" => "param_2"}}
     assert Ueberauth.Strategy.Helpers.callback_url(conn) ==
-      "https://www.example.com/auth/provider/callback"
+      "http://www.example.com?type=user"
   end
 
   defp assert_standard_info(auth) do


### PR DESCRIPTION
I added ability to specify :callback_params in settings for strategies 

 
```
config :ueberauth, Ueberauth,
   providers: [
     facebook: { Ueberauth.Strategy.Facebook, [callback_params: ["type", "user_role"]]} 
]
```

then add this extra param to login/sign-up links 
```

 auth_path(@conn, :request, "facebook", type: "sign-in")
 auth_path(@conn, :request, "twitter", user_role: "manager")
```

Tested on facebook twitter and VK strategies. 