### PR TITLE
Make travis green. Update travis config to reflect minimum elixir version in mix.exs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,17 @@
 language: elixir
 sudo: false
 elixir:
+  - 1.6
   - 1.5
   - 1.4
-  - 1.3
 otp_release:
-  - 20.0
+  - 20.2
   - 19.3
   - 18.3
 matrix:
   exclude:
-    - elixir: 1.3
-      otp_release: 20.0
+    - elixir: 1.6
+      otp_release: 18.3
 notifications:
   email: false
 script:

--- a/mix.exs
+++ b/mix.exs
@@ -26,7 +26,7 @@ defmodule Ueberauth.Mixfile do
     [{:plug, "~> 1.2"},
 
      # dev/test dependencies
-     {:credo, "~> 0.5", only: [:dev, :test]},
+     {:credo, "~> 0.8.10", only: [:dev, :test]},
      {:earmark, "~> 0.2", only: :dev},
      {:ex_doc, "~> 0.12", only: :dev}]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,8 @@
-%{"bunt": {:hex, :bunt, "0.1.6", "5d95a6882f73f3b9969fdfd1953798046664e6f77ec4e486e6fafc7caad97c6f", [:mix], []},
-  "credo": {:hex, :credo, "0.5.3", "0c405b36e7651245a8ed63c09e2d52c2e2b89b6d02b1570c4d611e0fcbecf4a2", [:mix], [{:bunt, "~> 0.1.6", [hex: :bunt, optional: false]}]},
+%{
+  "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm"},
+  "credo": {:hex, :credo, "0.8.10", "261862bb7363247762e1063713bb85df2bbd84af8d8610d1272cd9c1943bba63", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}], "hexpm"},
   "earmark": {:hex, :earmark, "0.2.1", "ba6d26ceb16106d069b289df66751734802777a3cbb6787026dd800ffeb850f3", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.12.0", "b774aabfede4af31c0301aece12371cbd25995a21bb3d71d66f5c2fe074c603f", [:mix], [{:earmark, "~> 0.2", [hex: :earmark, optional: false]}]},
   "mime": {:hex, :mime, "1.0.1", "05c393850524767d13a53627df71beeebb016205eb43bfbd92d14d24ec7a1b51", [:mix], []},
-  "plug": {:hex, :plug, "1.2.0", "496bef96634a49d7803ab2671482f0c5ce9ce0b7b9bc25bc0ae8e09859dd2004", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, optional: true]}, {:mime, "~> 1.0", [hex: :mime, optional: false]}]}}
+  "plug": {:hex, :plug, "1.2.0", "496bef96634a49d7803ab2671482f0c5ce9ce0b7b9bc25bc0ae8e09859dd2004", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, optional: true]}, {:mime, "~> 1.0", [hex: :mime, optional: false]}]},
+}


### PR DESCRIPTION
This PR should make Travis green.


* Add elixir 1.6 to travis config
* Update exclude option to not use OTP 18.3 and Elixir 1.6 which is not supported
by Elixir 1.6
* Remove elixir 1.3 from travis build since it was dropped in the 0.5.0 release (https://github.com/ueberauth/ueberauth/commit/d648d8f3938f3e64923d381e243f887ed75bf427)