### PR TITLE
fill in missing image in info typespec

### DIFF
--- a/lib/ueberauth/auth/info.ex
+++ b/lib/ueberauth/auth/info.ex
@@ -12,6 +12,7 @@ defmodule Ueberauth.Auth.Info do
               email: binary | nil,
               location: binary | nil,
               description: binary | nil,
+              image: binary | nil,
               phone: binary | nil,
               urls: map
              }


### PR DESCRIPTION
## Description

- The typespec was missing the image field.

- This MR fills it in.