### PR TITLE
upgrade deps

### DIFF
--- a/lib/ueberauth/strategies/helpers.ex
+++ b/lib/ueberauth/strategies/helpers.ex
@@ -6,7 +6,7 @@ defmodule Ueberauth.Strategy.Helpers do
   to the specific pipelined strategy, considering the pipelined options and
   falling back to defaults.
   """
-  import Plug.Conn
+  import Plug.Conn, except: [request_url: 1]
   alias Ueberauth.Failure
   alias Ueberauth.Failure.Error
 

--- a/lib/ueberauth/strategy.ex
+++ b/lib/ueberauth/strategy.ex
@@ -259,7 +259,7 @@ defmodule Ueberauth.Strategy do
     quote do
       @behaviour Ueberauth.Strategy
       import Ueberauth.Strategy.Helpers
-      import Plug.Conn
+      import Plug.Conn, except: [request_url: 1]
 
       def default_options, do: unquote(opts)
 

--- a/mix.exs
+++ b/mix.exs
@@ -21,17 +21,15 @@ defmodule Ueberauth.Mixfile do
   end
 
   def application do
-    [applications: [:logger]]
+    [extra_applications: [:logger]]
   end
 
   defp deps do
     [
-      {:plug, "~> 1.2"},
+      {:plug, "~> 1.5.0"},
 
       # dev/test dependencies
-      {:credo, "~> 0.8.10", only: [:dev, :test]},
-      {:earmark, "~> 0.2", only: :dev},
-      {:ex_doc, "~> 0.12", only: :dev}
+      {:ex_doc, "~> 0.18.0", only: :dev}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,8 +1,6 @@
 %{
-  "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm"},
-  "credo": {:hex, :credo, "0.8.10", "261862bb7363247762e1063713bb85df2bbd84af8d8610d1272cd9c1943bba63", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}], "hexpm"},
-  "earmark": {:hex, :earmark, "0.2.1", "ba6d26ceb16106d069b289df66751734802777a3cbb6787026dd800ffeb850f3", [:mix], []},
-  "ex_doc": {:hex, :ex_doc, "0.12.0", "b774aabfede4af31c0301aece12371cbd25995a21bb3d71d66f5c2fe074c603f", [:mix], [{:earmark, "~> 0.2", [hex: :earmark, optional: false]}]},
-  "mime": {:hex, :mime, "1.0.1", "05c393850524767d13a53627df71beeebb016205eb43bfbd92d14d24ec7a1b51", [:mix], []},
-  "plug": {:hex, :plug, "1.2.0", "496bef96634a49d7803ab2671482f0c5ce9ce0b7b9bc25bc0ae8e09859dd2004", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, optional: true]}, {:mime, "~> 1.0", [hex: :mime, optional: false]}]},
+  "earmark": {:hex, :earmark, "1.2.5", "4d21980d5d2862a2e13ec3c49ad9ad783ffc7ca5769cf6ff891a4553fbaae761", [:mix], [], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.18.3", "f4b0e4a2ec6f333dccf761838a4b253d75e11f714b85ae271c9ae361367897b7", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
+  "mime": {:hex, :mime, "1.2.0", "78adaa84832b3680de06f88f0997e3ead3b451a440d183d688085be2d709b534", [:mix], [], "hexpm"},
+  "plug": {:hex, :plug, "1.5.0", "224b25b4039bedc1eac149fb52ed456770b9678bbf0349cdd810460e1e09195b", [:mix], [{:cowboy, "~> 1.0.1 or ~> 1.1 or ~> 2.1", [hex: :cowboy, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}], "hexpm"},
 }


### PR DESCRIPTION
## Deps upgrade

- Upgrade dependencies

- One noticeable change is for `Plug ~> 1.5` the `except: [request_url: 1]` to avoid duplication import of the same function from `Plug.Conn`.

- Removed credo dependency on request by @doomspork 