### PR TITLE
Fixed Ueberauth request not respecting Script Name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.6.1
+
++ Fix versioning for `plug` dependency
+
 # 0.4.0
 
 + Target Elixir 1.3 and above

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Ueberauth.Mixfile do
   use Mix.Project
 
-  @version "0.6.0"
+  @version "0.6.1"
 
   def project do
     [


### PR DESCRIPTION
- When a router forwards traffic to another router, the conn will have it script name set.
- Read from it and override request / callback paths as well for good measure to accommodate umbrella structures.

This is a follow-up PR to address the scenario of per-app Ueberuath pipelines existing in an Umbrella app. Although configuration is loaded properly, in case the individual apps do not have individual Endpoints (instead, they just have Routers and a central Endpoint + Router forward traffic to them), then the incoming conn will have `script_name` set, which may or may not be reflected in configuration for each individual provider.

So for example, a Google Ueberauth provider will expect callbacks to hit `/auth/google/callback` by default although it may be hosted in an app whose Endpoint is getting forwarded traffic starting with `/myapp`. This set of changes in particular reads `script_name` dynamically and passes it on, so the provider gets paths that are correct and relative to root instead of relative to the root of the router.