### PR TITLE
No need to add Ueberauth to the application list (#117)

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,12 +78,6 @@ Looking for an example? Take a look [ueberauth/ueberauth_example](https://github
 ```elixir
 # mix.exs
 
-def application do
-  # Add the application to your list of applications.
-  # This will ensure that it will be included in a release.
-  [applications: [:logger, :ueberauth]]
-end
-
 defp deps do
   # Add the dependency
   [{:ueberauth, "~> 0.6"}]


### PR DESCRIPTION
Note: I don't know how common it is to run old elixir version in the wild and what is the last version where it was necessary to add Ueberauth to the application list.

If you think it is necessary, I can also mention the extra step needed for old elixir version.