### PR TITLE
Fixed routing issue when route_prefix not in request_path

### DIFF
--- a/lib/ueberauth.ex
+++ b/lib/ueberauth.ex
@@ -245,7 +245,12 @@ defmodule Ueberauth do
   def call(conn, routes) do
     route_prefix = Path.join(["/" | conn.script_name])
     route_path = Path.relative_to(conn.request_path, route_prefix)
-    route_key = {"/" <> route_path, conn.method}
+
+    route_key =
+      case route_path do
+        "/" <> _rest -> {route_path, conn.method}
+        route_path -> {"/" <> route_path, conn.method}
+      end
 
     case List.keyfind(routes, route_key, 0) do
       {_, route_mfa} -> run(conn, route_mfa)

--- a/lib/ueberauth.ex
+++ b/lib/ueberauth.ex
@@ -245,12 +245,7 @@ defmodule Ueberauth do
   def call(conn, routes) do
     route_prefix = Path.join(["/" | conn.script_name])
     route_path = Path.relative_to(conn.request_path, route_prefix)
-
-    route_key =
-      case route_path do
-        "/" <> _rest -> {route_path, conn.method}
-        route_path -> {"/" <> route_path, conn.method}
-      end
+    route_key = {normalize_route_path(route_path), conn.method}
 
     case List.keyfind(routes, route_key, 0) do
       {_, route_mfa} -> run(conn, route_mfa)
@@ -364,6 +359,10 @@ defmodule Ueberauth do
       list when is_list(list) -> list |> Enum.map(&get_env/1) |> Enum.reduce(&Keyword.merge/2)
     end
   end
+
+  # Used by `call/2`. Prefixes the route_path with a "/" only if there is not one already.
+  defp normalize_route_path("/" <> _rest = route_path), do: route_path
+  defp normalize_route_path(route_path), do: "/" <> route_path
 
   defp get_providers(environment, options) do
     #


### PR DESCRIPTION
This handles an issue when the route_prefix is not found in the request_path.
e.g. when 
```elixir
route_prefix = "/audit_logs"
conn.request_path = "/auth/github"
```
Then the route key incorrectly becomes `//auth/github`.
This patch fixes it to ensure that it stays as `/auth/github`

For context, this situation arose from me setting my endpoint url.path to "/audit_logs", but using an ingress controller to rewrite the "/audit_logs" prefix out of all requests once it's forwarded to the application. This is due to phoenix sockets not using the endpoint path.