### PR TITLE
Properly handle redirect uri calculation for phoenix app that do not run on the root of the host

### DIFF
--- a/lib/ueberauth/strategies/helpers.ex
+++ b/lib/ueberauth/strategies/helpers.ex
@@ -165,37 +165,16 @@ defmodule Ueberauth.Strategy.Helpers do
   end
 
   defp full_url(conn, path, opts) do
-    scheme =
-      conn
-      |> forwarded_proto
-      |> coalesce(conn.scheme)
-      |> normalize_scheme
+    endpoint = Phoenix.Controller.endpoint_module(conn)
+    uri = endpoint.struct_url()
 
     %URI{
-      host: conn.host,
-      port: normalize_port(scheme, conn.port),
-      path: path,
-      query: encode_query(opts),
-      scheme: to_string(scheme)
+      uri
+      | path: endpoint.path(path),
+        query: encode_query(opts)
     }
     |> to_string
   end
-
-  defp forwarded_proto(conn) do
-    conn
-    |> Plug.Conn.get_req_header("x-forwarded-proto")
-    |> List.first()
-  end
-
-  defp normalize_scheme("https"), do: :https
-  defp normalize_scheme("http"), do: :http
-  defp normalize_scheme(scheme), do: scheme
-
-  defp coalesce(nil, second), do: second
-  defp coalesce(first, _), do: first
-
-  defp normalize_port(:https, 80), do: 443
-  defp normalize_port(_, port), do: port
 
   defp encode_query([]), do: nil
   defp encode_query(opts), do: URI.encode_query(opts)


### PR DESCRIPTION
At the moment the full_url helper function used to calculate the callback uri does not consider the `path` option that might be set on the Router module. 

I ran into weird issues with Sign In With Apple (`ueberauth_apple`) because apple seems to be the only ones actually checking whether the redirect_uri passed when retrieving the access_token matches the one passed when first getting the authorization code.

Basically our SSO app is running on `example.com/sso` with `sso` being set in the SSO.Endpoint config like so:
```
SSO.Web.Endpoint,
    url: [scheme: "https", port: 443, host: "${HOST}", path: "/sso"],
```
Now when ueberauth constructed the redirect_uri it only took the host and the callback_path resulting in something like `example.com/auth/apple/callback` rather than `example.com/sso/auth/callback`.

This PR fixes this issue and also gets rid of some homebrewed normalizing that is available from Phoenix as well. 