### PR TITLE
Remove dublicated call to handle_callback_result

### DIFF
--- a/lib/ueberauth/strategy.ex
+++ b/lib/ueberauth/strategy.ex
@@ -306,7 +306,6 @@ defmodule Ueberauth.Strategy do
       strategy
       |> apply(:handle_callback!, [conn])
       |> handle_callback_result(strategy)
-      |> handle_callback_result(strategy)
 
     apply(strategy, :handle_cleanup!, [handled_conn])
   end


### PR DESCRIPTION
While investigating #121, I thought this was the culpit, unfortunately, this does not seem to resolve the issue, but I think we should still remove this duplication to avoid confusion in the future.