### PR TITLE
Misc doc generation changes

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,7 +1,4 @@
+# Used by "mix format"
 [
-  inputs: [
-    "mix.exs",
-    ".formatter.exs",
-    "{config,lib,test}/**/*.{ex,exs}"
-  ]
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
 ]

--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,29 @@
-/_build
-/deps
-/.dialyzer
+# The directory Mix will write compiled artifacts to.
+/_build/
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover/
+
+# The directory Mix downloads your dependencies sources to.
+/deps/
+
+# Where third-party dependencies like ExDoc output generated docs.
+/doc/
+
+# Ignore .fetch files in case you like to edit your project deps locally.
+/.fetch
+
+# If the VM crashes, it generates a dump, let's ignore it too.
 erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
 *.ez
-doc
+
+# Ignore package tarball (built via "mix hex.build").
+ueberauth-*.tar
+
+# Temporary files for e.g. tests.
+/tmp/
+
+# Misc.
 .DS_Store
-.elixir_ls/
-/.idea
-/docs
-/cover

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,34 +1,37 @@
 # Changelog
 
-## v0.6.3
+## v0.6.3 - 2020-03-05
+
 - Dynamic providers
 - Birthday part of info struct
 
-## v0.6.2
+## v0.6.2 - 2019-09-11
 
 - Fixed Ueberauth request not respecting Script Name [#97](https://github.com/ueberauth/ueberauth/pull/97)
 
-## v0.6.1
+## v0.6.1 - 2019-03-14
 
 - Fix versioning for `plug` dependency
 
-## v0.4.0
+## v0.4.0 - 2016-09-21
 
 - Target Elixir 1.3 and above
 - Fix Elixir 1.4 warnings
 - Fix bug preventing multiple providers
 
-## v0.3.0
+## v0.3.0 - 2016-07-19
 
 - Allow `:redirect_url` to be configured
 - Handle requests with or without trailing slash
 
-## v0.2.1
+## v0.2.1 - 2015-12-23
 
 - Add the ability to select which providers to use on a per-plug basis
 
-## v0.2.0
+## v0.2.0 - 2015-11-28
 
 - Remove the Ueberauth.plug function in favour of making Ueberauth a plug
 
-2015-11-15 Initial release
+## v0.1.0 - 2015-11-15
+
+- Initial release

--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
 # Überauth
+
 [![Build Status](https://travis-ci.org/ueberauth/ueberauth.svg?branch=master)](https://travis-ci.org/ueberauth/ueberauth)
 [![Codecov](https://codecov.io/gh/ueberauth/ueberauth/branch/master/graph/badge.svg)](https://codecov.io/gh/ueberauth/ueberauth)
 [![Inline docs](http://inch-ci.org/github/ueberauth/ueberauth.svg)](http://inch-ci.org/github/ueberauth/ueberauth)
 [![Hex Version](http://img.shields.io/hexpm/v/ueberauth.svg)](https://hex.pm/packages/ueberauth)
 [![Hex docs](http://img.shields.io/badge/hex.pm-docs-green.svg)](https://hexdocs.pm/ueberauth)
+[![Total Download](https://img.shields.io/hexpm/dt/ueberauth.svg)](https://hex.pm/packages/ueberauth)
 [![License](https://img.shields.io/hexpm/l/ueberauth.svg)](https://github.com/ueberauth/ueberauth/blob/master/LICENSE)
+[![Last Updated](https://img.shields.io/github/last-commit/ueberauth/ueberauth.svg)](https://github.com/ueberauth/ueberauth/commits/master)
+
 
 > An Elixir Authentication System for Plug-based Web Applications
 
@@ -164,7 +168,7 @@ config :ueberauth, Ueberauth,
 
 ## Customizing JSON Serializer
 
-Your json serializer can be configured depending on what you have installed in your application.  Defaults to [Jason](https://github.com/michalmuskala/jason).
+Your JSON serializer can be configured depending on what you have installed in your application.  Defaults to [Jason](https://github.com/michalmuskala/jason).
 
 ```elixir
 config :ueberauth, Ueberauth,
@@ -173,7 +177,7 @@ config :ueberauth, Ueberauth,
 
 ## HTTP Methods
 
-By default, all callback urls are only available via the `"GET"` method. You
+By default, all callback URLs are only available via the `"GET"` method. You
 can override this via options to your strategy.
 
 ```elixir
@@ -187,5 +191,8 @@ providers: [
 All options that are passed into your strategy are available at runtime to
 modify the behaviour of the strategy.
 
-## License
-See [LICENSE](https://raw.githubusercontent.com/ueberauth/ueberauth/master/LICENSE).
+## Copyright and License
+
+Copyright (c) 2015 Sonny Scroggin
+
+Released under the MIT License, which can be found in the repository in [`LICENSE`](https://raw.githubusercontent.com/ueberauth/ueberauth/master/LICENSE).

--- a/lib/ueberauth.ex
+++ b/lib/ueberauth.ex
@@ -104,7 +104,7 @@ defmodule Ueberauth do
   checks so your strategies will only fire for relevant requests.
 
   Now that you have this, your strategies will intercept relevant requests for
-  each strategy for both request and callback phases. The default urls are (for
+  each strategy for both request and callback phases. The default URLs are (for
   our Facebook & GitHub example)
 
       # Request phase paths
@@ -171,7 +171,7 @@ defmodule Ueberauth do
 
   #### Http Methods
 
-  By default, all callback urls are only available via the `"GET"` method. You
+  By default, all callback URLs are only available via the `"GET"` method. You
   can override this via options to your strategy.
 
       providers: [
@@ -201,9 +201,9 @@ defmodule Ueberauth do
   @doc """
   Fetch the configured JSON library.
 
-  A json library is required for Ueberauth to operate.
+  A JSON library is required for Ueberauth to operate.
 
-  In config.exs your implicit or expicit configuration is:
+  In config.exs your implicit or explicit configuration is:
 
       config :ueberauth, Ueberauth, json_library: Jason
 
@@ -227,7 +227,7 @@ defmodule Ueberauth do
       end
 
   This file will serve underlying Ueberauth libraries as a hook to grab the
-  configured json library.
+  configured JSON library.
   """
   def json_library(otp_app \\ nil) do
     environment = get_env([:ueberauth, otp_app])

--- a/lib/ueberauth/auth.ex
+++ b/lib/ueberauth/auth.ex
@@ -4,7 +4,7 @@ defmodule Ueberauth.Auth do
 
   This struct is constructed by the strategy by using functions defined in the
   strategy and is provided to the downstream plug in the connections assigns
-  `:ueberauth_auth` key
+  `:ueberauth_auth` key.
   """
 
   alias Ueberauth.Auth

--- a/lib/ueberauth/auth/info.ex
+++ b/lib/ueberauth/auth/info.ex
@@ -1,6 +1,6 @@
 defmodule Ueberauth.Auth.Info do
   @moduledoc """
-  Provides a place within the Ueberauth.Auth struct for information about the user.
+  Provides a place within the `Ueberauth.Auth` struct for information about the user.
   """
   alias Ueberauth.Auth.Info
 

--- a/lib/ueberauth/failure.ex
+++ b/lib/ueberauth/failure.ex
@@ -13,7 +13,7 @@ defmodule Ueberauth.Failure do
 
   # the provider name
   defstruct provider: nil,
-            # the strategy module tha ran
+            # the strategy module that ran
             strategy: nil,
             # Ueberauth.Failure.Error collection of strategy defined errors
             errors: []

--- a/mix.exs
+++ b/mix.exs
@@ -1,6 +1,7 @@
 defmodule Ueberauth.Mixfile do
   use Mix.Project
 
+  @source_url "https://github.com/ueberauth/ueberauth"
   @version "0.6.3"
 
   def project do
@@ -8,13 +9,11 @@ defmodule Ueberauth.Mixfile do
       app: :ueberauth,
       name: "Überauth",
       version: @version,
-      elixir: "~> 1.4",
+      elixir: "~> 1.7",
       elixirc_paths: elixirc_paths(Mix.env()),
       package: package(),
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
-      source_url: "https://github.com/ueberauth/ueberauth",
-      homepage_url: "https://github.com/ueberauth/ueberauth",
       description: description(),
       deps: deps(),
       docs: docs(),
@@ -41,13 +40,19 @@ defmodule Ueberauth.Mixfile do
       {:dialyxir, ">= 0.0.0", only: [:dev], runtime: false},
       {:credo, ">= 0.0.0", only: [:dev, :test], runtime: false},
       {:excoveralls, ">= 0.0.0", only: [:test], runtime: false},
-      {:ex_doc, "~> 0.19", only: [:dev], runtime: false},
+      {:ex_doc, ">= 0.0.0", only: [:dev], runtime: false},
       {:inch_ex, ">= 0.0.0", only: [:dev], runtime: false}
     ]
   end
 
   defp docs do
-    [extras: ["README.md", "CONTRIBUTING.md"]]
+    [
+      extras: ["CHANGELOG.md", "README.md", "CONTRIBUTING.md"],
+      main: "readme",
+      source_url: @source_url,
+      homepage_url: @source_url,
+      formatters: ["html"]
+    ]
   end
 
   defp description do
@@ -56,10 +61,13 @@ defmodule Ueberauth.Mixfile do
 
   defp package do
     [
-      files: ["lib", "mix.exs", "README.md", "LICENSE"],
+      files: ["lib", "mix.exs", "CHANGELOG.md", "README.md", "LICENSE"],
       maintainers: ["Sonny Scroggin", "Daniel Neighman", "Sean Callan"],
       licenses: ["MIT"],
-      links: %{"GitHub" => "https://github.com/ueberauth/ueberauth"}
+      links: %{
+        "Changelog" => "https://hexdocs.pm/ueberauth/changelog.html",
+        "GitHub" => @source_url
+      }
     ]
   end
 end


### PR DESCRIPTION
Besides other changes, this commit ensures the generated HTML doc for
HexDocs.pm will become the main source doc for this Elixir library which
leverage on ExDoc features.

List of changes:
* Use common source url
* Add changelog to html doc
* Add release date to changelog
* Update license section
* Badges and more badges!
* Fix typos
* Update gitignore
* Update formatter config
* Set output to html only
* Set and use latest ex_doc
* Follow minimum Elixir version with Travis CI