### PR TITLE
Make a proper way to clean state cookie

### DIFF
--- a/lib/ueberauth/strategy.ex
+++ b/lib/ueberauth/strategy.ex
@@ -358,6 +358,8 @@ defmodule Ueberauth.Strategy do
   end
 
   defp run_handle_callback(conn, strategy) do
+    conn = remove_state_cookie(conn)
+
     strategy
     |> apply(:handle_callback!, [conn])
     |> handle_callback_result(strategy)
@@ -365,7 +367,6 @@ defmodule Ueberauth.Strategy do
   end
 
   defp run_handle_cleanup(conn, strategy) do
-    conn = remove_state_cookie(conn)
     apply(strategy, :handle_cleanup!, [conn])
   end
 

--- a/lib/ueberauth/strategy.ex
+++ b/lib/ueberauth/strategy.ex
@@ -263,7 +263,7 @@ defmodule Ueberauth.Strategy do
   ### Cross-Site Request Forgery
 
   By default strategies must implement https://tools.ietf.org/html/rfc6749#section-10.12
-  if you wish to disabled such feature, use `:ignores_csrf_attack` option:
+  if you wish to disable such feature, use `:ignores_csrf_attack` option:
 
       defmodule MyStrategy do
         use Ueberauth.Strategy,

--- a/test/support/provider_with_csrf_attack_enabled.ex
+++ b/test/support/provider_with_csrf_attack_enabled.ex
@@ -2,4 +2,21 @@ defmodule Support.ProviderWithCsrfAttackEnabled do
   @moduledoc false
   use Ueberauth.Strategy
   use Support.Mixins
+
+  def handle_callback!(%Plug.Conn{params: %{"code" => code, "next_url" => url}} = conn) do
+    uri = URI.parse(url)
+    uri_query = uri.query || ""
+    query = URI.decode_query(uri_query) |> Map.put("code", code) |> URI.encode_query()
+    uri = %{uri | query: query} |> URI.to_string()
+    redirect!(conn, uri)
+  end
+
+  def handle_callback!(%Plug.Conn{params: %{"code" => _code}} = conn) do
+    conn
+  end
+
+  def handle_callback!(conn) do
+    set_errors!(conn, [error("missing_code", "No code received")])
+  end
+
 end

--- a/test/support/provider_with_csrf_attack_enabled.ex
+++ b/test/support/provider_with_csrf_attack_enabled.ex
@@ -6,8 +6,8 @@ defmodule Support.ProviderWithCsrfAttackEnabled do
   def handle_callback!(%Plug.Conn{params: %{"code" => code, "next_url" => url}} = conn) do
     uri = URI.parse(url)
     uri_query = uri.query || ""
-    query = URI.decode_query(uri_query) |> Map.put("code", code) |> URI.encode_query()
-    uri = %{uri | query: query} |> URI.to_string()
+    query = uri_query |> URI.decode_query() |> Map.put("code", code) |> URI.encode_query()
+    uri = URI.to_string(%{uri | query: query})
     redirect!(conn, uri)
   end
 
@@ -18,5 +18,4 @@ defmodule Support.ProviderWithCsrfAttackEnabled do
   def handle_callback!(conn) do
     set_errors!(conn, [error("missing_code", "No code received")])
   end
-
 end

--- a/test/ueberauth_test.exs
+++ b/test/ueberauth_test.exs
@@ -230,7 +230,7 @@ defmodule UeberauthTest do
     assert List.first(conn.assigns.ueberauth_failure.errors).message_key == :csrf_attack
   end
 
-  test "make ensure run_callback is after the internal state clean" do
+  test "make ensure run_callback properly clean the internal state param in cookie" do
     conn =
       conn(:get, "/oauth/simple-provider/", id: "foo")
       |> Ueberauth.run_request(

--- a/test/ueberauth_test.exs
+++ b/test/ueberauth_test.exs
@@ -246,7 +246,12 @@ defmodule UeberauthTest do
 
     conn =
       :get
-      |> conn("/oauth/simple-provider/callback", next_url: "http://localhost/fetch_user", id: "foo", code: code, state: state)
+      |> conn("/oauth/simple-provider/callback",
+        next_url: "http://localhost/fetch_user",
+        id: "foo",
+        code: code,
+        state: state
+      )
       |> Map.put(:cookies, conn.cookies)
       |> Map.put(:req_cookies, conn.req_cookies)
       |> Plug.Session.call(@session_options)

--- a/test/ueberauth_test.exs
+++ b/test/ueberauth_test.exs
@@ -232,7 +232,8 @@ defmodule UeberauthTest do
 
   test "make ensure run_callback properly clean the internal state param in cookie" do
     conn =
-      conn(:get, "/oauth/simple-provider/", id: "foo")
+      :get
+      |> conn("/oauth/simple-provider/", id: "foo")
       |> Ueberauth.run_request(
         "simple-provider",
         {Support.ProviderWithCsrfAttackEnabled,
@@ -244,7 +245,8 @@ defmodule UeberauthTest do
     code = "simple-code"
 
     conn =
-      conn(:get, "/oauth/simple-provider/callback", next_url: "http://localhost/fetch_user", id: "foo", code: code, state: state)
+      :get
+      |> conn("/oauth/simple-provider/callback", next_url: "http://localhost/fetch_user", id: "foo", code: code, state: state)
       |> Map.put(:cookies, conn.cookies)
       |> Map.put(:req_cookies, conn.req_cookies)
       |> Plug.Session.call(@session_options)


### PR DESCRIPTION
Hello,

In the https://github.com/ueberauth/ueberauth/pull/136 PR, we add a feature to protect CSRF attack by put the `state` parameter into cookie, and we remove the `state` cookie is after the `handle_callback!/1` function of the strategy in this changes, before this PR changes, in the `handle_callback!/1` function of the strategy we can do any proper process with Plug, but now we may see a similar "AlreadySentError" error if we make a redirection in the `handle_callback!/1`:

```
  1) test make ensure run_callback properly clean the internal state param in cookie (UeberauthTest)
     test/ueberauth_test.exs:233
     ** (Plug.Conn.AlreadySentError) the response was already sent
     code: |> Ueberauth.run_callback(
     stacktrace:
       (plug 1.11.0) lib/plug/conn.ex:1720: Plug.Conn.update_cookies/2
       (ueberauth 0.6.3) lib/ueberauth/strategy.ex:370: Ueberauth.Strategy.run_handle_cleanup/2
       test/ueberauth_test.exs:251: (test)
```

In this PR, I change to put the `state` cookie clean before run `handle_callback!/1`, since the state parameter in cookie should be transparent for the strategy, and add a test case to catch this.

Please review and advise, cc @yordis @doomspork .

Thanks.