### PR TITLE
Add custom URL resolution scheme option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.8.0 - 2021-08-19
+
+- Add support for custom URL schemes [#144](https://github.com/ueberauth/ueberauth/pull/144)
+
 ## v0.7.0 - 2020-04-17
 
 - Add support for CSRF [#136](https://github.com/ueberauth/ueberauth/pull/136)

--- a/lib/ueberauth.ex
+++ b/lib/ueberauth.ex
@@ -169,6 +169,22 @@ defmodule Ueberauth do
         ],
         json_library: Poison # or Jason
 
+  #### Customizing Schemes
+
+  By default, Ueberauth uses your `Plug.Conn` scheme.
+
+  A custom scheme can be provided through the request header `X-Forwarded-Proto`.
+
+  For example, in Nginx you can set it.
+
+      proxy_set_header X-Forwarded-Proto $scheme;
+
+  Another option is to override this via options to your strategy.
+
+      providers: [
+        identity: {Ueberauth.Strategies.Identity, [callback_scheme: "https"]}
+      ]
+
   #### Http Methods
 
   By default, all callback URLs are only available via the `"GET"` method. You

--- a/lib/ueberauth.ex
+++ b/lib/ueberauth.ex
@@ -407,7 +407,9 @@ defmodule Ueberauth do
     %{
       strategy: module,
       strategy_name: name,
+      request_scheme: Keyword.get(options, :request_scheme),
       request_path: get_request_path(base_path, strategy),
+      callback_scheme: Keyword.get(options, :callback_scheme),
       callback_path: get_callback_path(base_path, strategy),
       callback_methods: get_callback_methods(options),
       options: options,

--- a/lib/ueberauth/strategies/helpers.ex
+++ b/lib/ueberauth/strategies/helpers.ex
@@ -43,23 +43,38 @@ defmodule Ueberauth.Strategy.Helpers do
   @doc """
   The full url for the request phase for the requests strategy.
 
-  The URL is based on the current requests host and scheme. The options will be
-  encoded as query params.
+  The URL is based on the current requests host and scheme.
   """
   @spec request_url(Plug.Conn.t()) :: String.t()
-  def request_url(conn, opts \\ []), do: full_url(conn, request_path(conn), opts)
+  def request_url(conn, query_params \\ []) do
+    opts = [
+      scheme: from_private(conn, :request_scheme),
+      path: request_path(conn),
+      query_params: query_params
+    ]
+
+    full_url(conn, opts)
+  end
 
   @doc """
   The full URL for the callback phase for the requests strategy.
 
-  The URL is based on the current requests host and scheme. The options will be
-  encoded as query params.
+  The URL is based on the current requests host and scheme.
   """
 
   @spec callback_url(Plug.Conn.t()) :: String.t()
-  def callback_url(conn, opts \\ []) do
-    from_private(conn, :callback_url) ||
-      full_url(conn, callback_path(conn), callback_params(conn, opts))
+  def callback_url(conn, query_params \\ []) do
+    if url = from_private(conn, :callback_url) do
+      url
+    else
+      opts = [
+        scheme: from_private(conn, :callback_scheme),
+        path: callback_path(conn),
+        query_params: callback_params(conn, query_params)
+      ]
+
+      full_url(conn, opts)
+    end
   end
 
   @doc """
@@ -68,7 +83,7 @@ defmodule Ueberauth.Strategy.Helpers do
   This method will filter conn.params with whitelisted params from :callback_params settings
   """
   @spec callback_params(Plug.Conn.t()) :: keyword()
-  def callback_params(conn, opts \\ []) do
+  def callback_params(conn, query_params \\ []) do
     callback_params = from_private(conn, :callback_params) || []
 
     callback_params =
@@ -77,7 +92,7 @@ defmodule Ueberauth.Strategy.Helpers do
       |> Enum.filter(fn {_, v} -> v != nil end)
       |> Enum.filter(fn {k, _} -> k != "provider" end)
 
-    Keyword.merge(opts, callback_params)
+    Keyword.merge(query_params, callback_params)
   end
 
   @doc """
@@ -189,41 +204,40 @@ defmodule Ueberauth.Strategy.Helpers do
     if opts, do: opts[key], else: nil
   end
 
-  defp full_url(conn, path, opts) do
+  defp full_url(conn, opts) do
     scheme =
-      conn
-      |> forwarded_proto
-      |> coalesce(conn.scheme)
-      |> normalize_scheme
+      cond do
+        scheme = Keyword.get(opts, :scheme) -> scheme
+        scheme = get_forwarded_proto_header(conn) -> scheme
+        true -> to_string(conn.scheme)
+      end
+
+    encoded_query =
+      opts
+      |> Keyword.get(:query_params, [])
+      |> encode_query()
 
     %URI{
       host: conn.host,
       port: normalize_port(scheme, conn.port),
-      path: path,
-      query: encode_query(opts),
-      scheme: to_string(scheme)
+      path: Keyword.fetch!(opts, :path),
+      query: encoded_query,
+      scheme: scheme
     }
-    |> to_string
+    |> to_string()
   end
 
-  defp forwarded_proto(conn) do
+  defp get_forwarded_proto_header(conn) do
     conn
-    |> Plug.Conn.get_req_header("x-forwarded-proto")
+    |> get_req_header("x-forwarded-proto")
     |> List.first()
   end
 
-  defp normalize_scheme("https"), do: :https
-  defp normalize_scheme("http"), do: :http
-  defp normalize_scheme(scheme), do: scheme
-
-  defp coalesce(nil, second), do: second
-  defp coalesce(first, _), do: first
-
-  defp normalize_port(:https, 80), do: 443
+  defp normalize_port("https", 80), do: 443
   defp normalize_port(_, port), do: port
 
   defp encode_query([]), do: nil
-  defp encode_query(opts), do: URI.encode_query(opts)
+  defp encode_query(query_params), do: URI.encode_query(query_params)
 
   defp map_errors(nil), do: []
   defp map_errors([]), do: []

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Ueberauth.Mixfile do
   use Mix.Project
 
   @source_url "https://github.com/ueberauth/ueberauth"
-  @version "0.7.0"
+  @version "0.8.0"
 
   def project do
     [

--- a/test/ueberauth_test.exs
+++ b/test/ueberauth_test.exs
@@ -161,6 +161,23 @@ defmodule UeberauthTest do
              "https://www.example.com/auth/provider/callback"
   end
 
+  test "callback_url has custom scheme" do
+    conn = %{
+      conn(:get, "/")
+      | scheme: :http,
+        port: 80
+    }
+
+    conn =
+      put_private(conn, :ueberauth_request_options,
+        callback_path: "/auth/provider/callback",
+        callback_scheme: "https"
+      )
+
+    assert Ueberauth.Strategy.Helpers.callback_url(conn) ==
+             "https://www.example.com/auth/provider/callback"
+  end
+
   test "callback_url has extra params" do
     conn = conn(:get, "/")
     conn = put_private(conn, :ueberauth_request_options, callback_params: ["type"])


### PR DESCRIPTION
In our scenario, we cannot support `X-Forwarded-Proto` header due to network and security constrains related to our business case, therefore, we'd like to have the option to use a custom `https` scheme for callbacks instead

I think this is also related to https://github.com/ueberauth/ueberauth/issues/103 and https://github.com/ueberauth/ueberauth/issues/65

So, for now I'll just add a custom scheme option, but if and when this PR is approved and merged, I'd like to also add a custom port option, to better solve the issue aforementioned
