### PR TITLE
Add custom URL resolution port option

### DIFF
--- a/lib/ueberauth.ex
+++ b/lib/ueberauth.ex
@@ -185,6 +185,16 @@ defmodule Ueberauth do
         identity: {Ueberauth.Strategies.Identity, [callback_scheme: "https"]}
       ]
 
+  #### Customizing Ports
+
+  By default, Ueberauth uses your `Plug.Conn` port.
+
+  To override this via options to your strategy.
+
+      providers: [
+        identity: {Ueberauth.Strategies.Identity, [callback_port: 4000]}
+      ]
+
   #### Http Methods
 
   By default, all callback URLs are only available via the `"GET"` method. You
@@ -425,8 +435,10 @@ defmodule Ueberauth do
       strategy_name: name,
       request_scheme: Keyword.get(options, :request_scheme),
       request_path: get_request_path(base_path, strategy),
+      request_port: Keyword.get(options, :request_port),
       callback_scheme: Keyword.get(options, :callback_scheme),
       callback_path: get_callback_path(base_path, strategy),
+      callback_port: Keyword.get(options, :callback_port),
       callback_methods: get_callback_methods(options),
       options: options,
       callback_url: Keyword.get(options, :callback_url),

--- a/lib/ueberauth/strategies/helpers.ex
+++ b/lib/ueberauth/strategies/helpers.ex
@@ -49,6 +49,7 @@ defmodule Ueberauth.Strategy.Helpers do
   def request_url(conn, query_params \\ []) do
     opts = [
       scheme: from_private(conn, :request_scheme),
+      port: from_private(conn, :request_port),
       path: request_path(conn),
       query_params: query_params
     ]
@@ -69,6 +70,7 @@ defmodule Ueberauth.Strategy.Helpers do
     else
       opts = [
         scheme: from_private(conn, :callback_scheme),
+        port: from_private(conn, :callback_port),
         path: callback_path(conn),
         query_params: callback_params(conn, query_params)
       ]
@@ -212,16 +214,24 @@ defmodule Ueberauth.Strategy.Helpers do
         true -> to_string(conn.scheme)
       end
 
-    encoded_query =
+    port =
+      cond do
+        port = Keyword.get(opts, :port) -> port
+        true -> normalize_port(scheme, conn.port)
+      end
+
+    path = Keyword.fetch!(opts, :path)
+
+    query =
       opts
       |> Keyword.get(:query_params, [])
       |> encode_query()
 
     %URI{
       host: conn.host,
-      port: normalize_port(scheme, conn.port),
-      path: Keyword.fetch!(opts, :path),
-      query: encoded_query,
+      port: port,
+      path: path,
+      query: query,
       scheme: scheme
     }
     |> to_string()

--- a/test/ueberauth_test.exs
+++ b/test/ueberauth_test.exs
@@ -178,6 +178,23 @@ defmodule UeberauthTest do
              "https://www.example.com/auth/provider/callback"
   end
 
+  test "callback_url has custom port" do
+    conn = %{
+      conn(:get, "/")
+      | scheme: :http,
+        port: 80
+    }
+
+    conn =
+      put_private(conn, :ueberauth_request_options,
+        callback_path: "/auth/provider/callback",
+        callback_port: 4000
+      )
+
+    assert Ueberauth.Strategy.Helpers.callback_url(conn) ==
+             "http://www.example.com:4000/auth/provider/callback"
+  end
+
   test "callback_url has extra params" do
     conn = conn(:get, "/")
     conn = put_private(conn, :ueberauth_request_options, callback_params: ["type"])


### PR DESCRIPTION
Related to changes: https://github.com/ueberauth/ueberauth/pull/144
Also relates to issues #103 and #65

This adds a custom port option

Should I also add a host option to have the full URL configurable, wdyt?
