### PR TITLE
Fix route prefix (conn.script_name) in run/2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.8.0 - 2021-08-19
 
 - Add support for custom URL schemes [#144](https://github.com/ueberauth/ueberauth/pull/144)
+- Fix url path prefixes with more than one segment [#147](https://github.com/ueberauth/ueberauth/pull/147)
 
 ## v0.7.0 - 2020-04-17
 

--- a/lib/ueberauth.ex
+++ b/lib/ueberauth.ex
@@ -344,8 +344,9 @@ defmodule Ueberauth do
   end
 
   defp run(conn, {module, :run_request, options}) do
-    to_request_path = Path.join(["/", conn.script_name, options.request_path])
-    to_callback_path = Path.join(["/", conn.script_name, options.callback_path])
+    route_prefix     = Path.join(["/" | conn.script_name])
+    to_request_path  = Path.join(["/", route_prefix, options.request_path])
+    to_callback_path = Path.join(["/", route_prefix, options.callback_path])
     to_options = %{options | request_path: to_request_path, callback_path: to_callback_path}
 
     conn
@@ -354,8 +355,9 @@ defmodule Ueberauth do
   end
 
   defp run(conn, {module, :run_callback, options}) do
-    to_request_path = Path.join(["/", conn.script_name, options.request_path])
-    to_callback_path = Path.join(["/", conn.script_name, options.callback_path])
+    route_prefix     = Path.join(["/" | conn.script_name])
+    to_request_path  = Path.join(["/", route_prefix, options.request_path])
+    to_callback_path = Path.join(["/", route_prefix, options.callback_path])
     to_options = %{options | request_path: to_request_path, callback_path: to_callback_path}
 
     conn


### PR DESCRIPTION
Closes #146 - when the url path has a prefix with more than one segment, such as `example.com/a/b/`, yielding ueberauth routes such as `example.com/a/b/auth/:provider`, the path of the url is first calculated correctly in `Ueberauth.call/2`, but then calculated wrongly in the private function `Ueberauth.run/2`, creating `example.com/ab/auth/:provider` instead. This is because of:

`to_request_path = Path.join(["/", conn.script_name, options.request_path])`

where `conn.script_name` is `["a", "b"]`. The documentation of `Path.join` explicitly mentions that this will result in "a" and "b" being mashed together. As a result, the auth http calls don't reach their target.