### PR TITLE
Prefer `x-forwarded-host` to construct callback_url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.9.0 - 2022-04-27
+
+- Prefer `x-forwarded-host` to construct callback_url [#161](https://github.com/ueberauth/ueberauth/pull/161)
+
 ## v0.8.0 - 2021-08-19
 
 - Add support for custom URL schemes [#144](https://github.com/ueberauth/ueberauth/pull/144)

--- a/lib/ueberauth/strategies/helpers.ex
+++ b/lib/ueberauth/strategies/helpers.ex
@@ -218,13 +218,15 @@ defmodule Ueberauth.Strategy.Helpers do
 
     path = Keyword.fetch!(opts, :path)
 
+    host = get_forwarded_host_header(conn) || conn.host
+
     query =
       opts
       |> Keyword.get(:query_params, [])
       |> encode_query()
 
     %URI{
-      host: conn.host,
+      host: host,
       port: port,
       path: path,
       query: query,
@@ -236,6 +238,12 @@ defmodule Ueberauth.Strategy.Helpers do
   defp get_forwarded_proto_header(conn) do
     conn
     |> get_req_header("x-forwarded-proto")
+    |> List.first()
+  end
+
+  defp get_forwarded_host_header(conn) do
+    conn
+    |> get_req_header("x-forwarded-host")
     |> List.first()
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Ueberauth.Mixfile do
   use Mix.Project
 
   @source_url "https://github.com/ueberauth/ueberauth"
-  @version "0.8.0"
+  @version "0.9.0"
 
   def project do
     [

--- a/test/ueberauth_test.exs
+++ b/test/ueberauth_test.exs
@@ -161,6 +161,20 @@ defmodule UeberauthTest do
              "https://www.example.com/auth/provider/callback"
   end
 
+  test "callback_url uses forwarded host" do
+    conn = %{
+      (conn(:get, "/")
+       |> put_req_header("x-forwarded-host", "changelog.com"))
+      | scheme: :http,
+        port: 80
+    }
+
+    conn = put_private(conn, :ueberauth_request_options, callback_path: "/auth/provider/callback")
+
+    assert Ueberauth.Strategy.Helpers.callback_url(conn) ==
+             "http://changelog.com/auth/provider/callback"
+  end
+
   test "callback_url has custom scheme" do
     conn = %{
       conn(:get, "/")


### PR DESCRIPTION
This feature is similar to PR #14 that added support for differing port for apps behind proxies. 

We recently moved [our app](https://github.com/thechangelog/changelog.com) from Linode to Fly, which broke Ueberauth because the callback URL that gets generated uses the Fly app domain instead of our public [changelog.com](https://changelog.com) domain.

I have deployed and tested this change in production and confirmed it fixes the issue for us and you can sign in/up via Twitter and GitHub once again.