### PR TITLE
Add option for state param cookie SameSite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.9.1 - 2022-06-16
+## 0.10.0 - 2022-06-16
 
 - Add `state_param_cookie_same_site` to strategy options to support different SameSite values [#148](https://github.com/ueberauth/ueberauth/pull/164#issuecomment-1155406862)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.9.1 - 2022-06-16
+
+- Add `state_param_cookie_same_site` to strategy options to support different SameSite values [#148](https://github.com/ueberauth/ueberauth/pull/164#issuecomment-1155406862)
+
 ## v0.9.0 - 2022-04-27
 
 - Prefer `x-forwarded-host` to construct callback_url [#161](https://github.com/ueberauth/ueberauth/pull/161)

--- a/lib/ueberauth/strategy.ex
+++ b/lib/ueberauth/strategy.ex
@@ -278,6 +278,15 @@ defmodule Ueberauth.Strategy do
 
   We strongly recommend never disabling this feature, unless you have some technical
   limitations that forces you to do so.
+
+  To change the SameSite attribute of the cookie holding the state parameter, you can use the `:state_param_cookie_same_site` option:
+
+      defmodule MyStrategy do
+        use Ueberauth.Strategy,
+          state_param_cookie_same_site: "None"
+        # …
+      end
+
   """
   defmacro __using__(opts \\ []) do
     quote location: :keep do

--- a/lib/ueberauth/strategy.ex
+++ b/lib/ueberauth/strategy.ex
@@ -410,7 +410,9 @@ defmodule Ueberauth.Strategy do
     state = create_state_param()
 
     conn
-    |> Conn.put_resp_cookie(@state_param_cookie_name, state, same_site: get_state_param_cookie_same_site(strategy))
+    |> Conn.put_resp_cookie(@state_param_cookie_name, state,
+      same_site: get_state_param_cookie_same_site(strategy)
+    )
     |> Helpers.add_state_param(state)
   end
 

--- a/lib/ueberauth/strategy.ex
+++ b/lib/ueberauth/strategy.ex
@@ -379,21 +379,29 @@ defmodule Ueberauth.Strategy do
     if get_ignores_csrf_attack_option(strategy) do
       conn
     else
-      add_state_param(conn)
+      add_state_param(conn, strategy)
     end
   end
 
-  defp get_ignores_csrf_attack_option(strategy) do
-    strategy
-    |> apply(:default_options, [])
-    |> Keyword.get(:ignores_csrf_attack, false)
+  defp get_state_param_cookie_same_site(strategy) do
+    strategy_option(strategy, :state_param_cookie_same_site, "Lax")
   end
 
-  defp add_state_param(conn) do
+  defp get_ignores_csrf_attack_option(strategy) do
+    strategy_option(strategy, :ignores_csrf_attack, false)
+  end
+
+  defp strategy_option(strategy, name, fallback) do
+    strategy
+    |> apply(:default_options, [])
+    |> Keyword.get(name, fallback)
+  end
+
+  defp add_state_param(conn, strategy) do
     state = create_state_param()
 
     conn
-    |> Conn.put_resp_cookie(@state_param_cookie_name, state, same_site: "Lax")
+    |> Conn.put_resp_cookie(@state_param_cookie_name, state, same_site: get_state_param_cookie_same_site(strategy))
     |> Helpers.add_state_param(state)
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Ueberauth.Mixfile do
   use Mix.Project
 
   @source_url "https://github.com/ueberauth/ueberauth"
-  @version "0.9.1"
+  @version "0.10.0"
 
   def project do
     [

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Ueberauth.Mixfile do
   use Mix.Project
 
   @source_url "https://github.com/ueberauth/ueberauth"
-  @version "0.9.0"
+  @version "0.9.1"
 
   def project do
     [

--- a/test/support/provider_with_custom_cookie_same_site.ex
+++ b/test/support/provider_with_custom_cookie_same_site.ex
@@ -1,7 +1,8 @@
 defmodule Support.ProviderWithCustomCookieSameSite do
   @moduledoc false
   use Ueberauth.Strategy,
-  state_param_cookie_same_site: "None"
+    state_param_cookie_same_site: "None"
+
   use Support.Mixins
 
   def handle_callback!(%Plug.Conn{params: %{"code" => code, "next_url" => url}} = conn) do

--- a/test/support/provider_with_custom_cookie_same_site.ex
+++ b/test/support/provider_with_custom_cookie_same_site.ex
@@ -1,0 +1,22 @@
+defmodule Support.ProviderWithCustomCookieSameSite do
+  @moduledoc false
+  use Ueberauth.Strategy,
+  state_param_cookie_same_site: "None"
+  use Support.Mixins
+
+  def handle_callback!(%Plug.Conn{params: %{"code" => code, "next_url" => url}} = conn) do
+    uri = URI.parse(url)
+    uri_query = uri.query || ""
+    query = uri_query |> URI.decode_query() |> Map.put("code", code) |> URI.encode_query()
+    uri = URI.to_string(%{uri | query: query})
+    redirect!(conn, uri)
+  end
+
+  def handle_callback!(%Plug.Conn{params: %{"code" => _code}} = conn) do
+    conn
+  end
+
+  def handle_callback!(conn) do
+    set_errors!(conn, [error("missing_code", "No code received")])
+  end
+end

--- a/test/ueberauth_test.exs
+++ b/test/ueberauth_test.exs
@@ -251,7 +251,7 @@ defmodule UeberauthTest do
          [callback_path: "/oauth/simple-provider/callback"]}
       )
 
-      assert conn.resp_cookies["ueberauth.state_param"][:same_site] == "None"
+    assert conn.resp_cookies["ueberauth.state_param"][:same_site] == "None"
   end
 
   test "run_request with state param disabled" do

--- a/test/ueberauth_test.exs
+++ b/test/ueberauth_test.exs
@@ -242,6 +242,18 @@ defmodule UeberauthTest do
     assert conn.private[:ueberauth_state_param] != nil
   end
 
+  test "run_request with a custom state param cookie samesite" do
+    conn =
+      conn(:get, "/oauth/simple-provider/", id: "foo")
+      |> Ueberauth.run_request(
+        "simple-provider",
+        {Support.ProviderWithCustomCookieSameSite,
+         [callback_path: "/oauth/simple-provider/callback"]}
+      )
+
+      assert conn.resp_cookies["ueberauth.state_param"][:same_site] == "None"
+  end
+
   test "run_request with state param disabled" do
     conn =
       conn(:get, "/oauth/simple-provider/", id: "foo")


### PR DESCRIPTION
This PR adds a strategy option to change the SameSite value of the state param cookie.

Changing the same_site is required in certain scenarios like doing OAuth in an iframe.

see https://github.com/ueberauth/ueberauth/issues/148