### PR TITLE
Custom state parameters

### DIFF
--- a/lib/ueberauth/strategies/helpers.ex
+++ b/lib/ueberauth/strategies/helpers.ex
@@ -179,11 +179,22 @@ defmodule Ueberauth.Strategy.Helpers do
   end
 
   @doc """
-  Add state parameter to the `%Plug.Conn{}`.
+  Add state parameter to the `%Plug.Conn{}` during `request phase`.
   """
   @spec add_state_param(Plug.Conn.t(), String.t()) :: Plug.Conn.t()
   def add_state_param(conn, value) do
     Plug.Conn.put_private(conn, :ueberauth_state_param, value)
+  end
+
+  @doc """
+  Get state parameter from the `%Plug.Conn{}` during `callback phase`.
+  """
+  @spec get_state_param(Plug.Conn.t()) :: any() | nil
+  def get_state_param(conn) do
+    case @json_library.decode(conn.query_params["state"]) do
+      {:ok, %{"data" => data}} -> data
+      _else -> nil
+    end
   end
 
   @doc """

--- a/lib/ueberauth/strategies/helpers.ex
+++ b/lib/ueberauth/strategies/helpers.ex
@@ -10,6 +10,8 @@ defmodule Ueberauth.Strategy.Helpers do
   alias Ueberauth.Failure
   alias Ueberauth.Failure.Error
 
+  @json_library Ueberauth.json_library()
+
   @doc """
   Provides the name of the strategy or provider name.
 
@@ -211,12 +213,12 @@ defmodule Ueberauth.Strategy.Helpers do
 
     state =
       if conn.private[:ueberauth_state_param] do
-        Map.put(state, "state", conn.private[:ueberauth_state_param])
+        Map.put(state, "data", conn.private[:ueberauth_state_param])
       else
         state
       end
 
-    Keyword.put(opts, :state, state |> Jason.encode!())
+    Keyword.put(opts, :state, @json_library.encode!(state))
   end
 
   defp from_private(conn, key) do

--- a/lib/ueberauth/strategies/helpers.ex
+++ b/lib/ueberauth/strategies/helpers.ex
@@ -10,8 +10,6 @@ defmodule Ueberauth.Strategy.Helpers do
   alias Ueberauth.Failure
   alias Ueberauth.Failure.Error
 
-  @json_library Ueberauth.json_library()
-
   @doc """
   Provides the name of the strategy or provider name.
 
@@ -191,7 +189,7 @@ defmodule Ueberauth.Strategy.Helpers do
   """
   @spec get_state_param(Plug.Conn.t()) :: any() | nil
   def get_state_param(conn) do
-    case @json_library.decode(conn.query_params["state"]) do
+    case Ueberauth.json_library().decode(conn.query_params["state"]) do
       {:ok, %{"data" => data}} -> data
       _else -> nil
     end
@@ -229,7 +227,7 @@ defmodule Ueberauth.Strategy.Helpers do
         state
       end
 
-    Keyword.put(opts, :state, @json_library.encode!(state))
+    Keyword.put(opts, :state, Ueberauth.json_library().encode!(state))
   end
 
   defp from_private(conn, key) do

--- a/lib/ueberauth/strategies/helpers.ex
+++ b/lib/ueberauth/strategies/helpers.ex
@@ -189,9 +189,11 @@ defmodule Ueberauth.Strategy.Helpers do
   """
   @spec get_state_param(Plug.Conn.t()) :: any() | nil
   def get_state_param(conn) do
-    case Ueberauth.json_library().decode(conn.query_params["state"]) do
-      {:ok, %{"data" => data}} -> data
-      _else -> nil
+    with state when not is_nil(state) <- conn.query_params["state"],
+         {:ok, %{"data" => data}} <- Ueberauth.json_library().decode(state) do
+      data
+    else
+      _ -> nil
     end
   end
 

--- a/lib/ueberauth/strategy.ex
+++ b/lib/ueberauth/strategy.ex
@@ -155,6 +155,14 @@ defmodule Ueberauth.Strategy do
   Once you've set errors, Ueberauth will not set the auth struct in the connections
   assigns at `:ueberauth_auth`, instead it will set a `Ueberauth.Failure` struct at
   `:ueberauth_failure` with the information provided detailing the failure.
+
+  ### Pass custom data through state
+
+  It is possible to pass custom data between authorization request and the authorization
+  server's response.
+  In that case you should use `Ueberauth.Strategy.Helpers.add_state_param/2`
+  function during the `request phase`. Then you could read state data in `callback phase`
+  by calling `Ueberauth.Strategy.Helpers.get_state_param/1`.
   """
 
   alias Plug.Conn

--- a/lib/ueberauth/strategy.ex
+++ b/lib/ueberauth/strategy.ex
@@ -166,6 +166,7 @@ defmodule Ueberauth.Strategy do
   alias Ueberauth.Auth.Extra
 
   @anti_csrf_token_cookie_name "ueberauth.anti_csrf_token"
+  @json_library Ueberauth.json_library()
 
   @doc """
   The request phase implementation for your strategy.
@@ -357,7 +358,7 @@ defmodule Ueberauth.Strategy do
 
     param_cookie =
       if state != nil do
-        case Jason.decode(state) do
+        case @json_library.decode(state) do
           {:ok, decoded} -> decoded["csrf"]
           _else -> nil
         end

--- a/lib/ueberauth/strategy.ex
+++ b/lib/ueberauth/strategy.ex
@@ -174,7 +174,6 @@ defmodule Ueberauth.Strategy do
   alias Ueberauth.Auth.Extra
 
   @anti_csrf_token_cookie_name "ueberauth.anti_csrf_token"
-  @json_library Ueberauth.json_library()
 
   @doc """
   The request phase implementation for your strategy.
@@ -366,7 +365,7 @@ defmodule Ueberauth.Strategy do
 
     param_cookie =
       if state != nil do
-        case @json_library.decode(state) do
+        case Ueberauth.json_library().decode(state) do
           {:ok, decoded} -> decoded["csrf"]
           _else -> nil
         end

--- a/test/support/simple_provider_with_state.ex
+++ b/test/support/simple_provider_with_state.ex
@@ -5,14 +5,6 @@ defmodule Support.SimpleProviderWithState do
 
   def uid(%{params: %{"id" => id}} = _conn), do: id
 
-  def credentials(%{params: %{"code" => code}} = conn) do
-    prefix = options(conn)[:token_prefix]
-
-    %Ueberauth.Auth.Credentials{
-      token: "#{prefix}#{code}"
-    }
-  end
-
   def handle_request!(conn) do
     callback = options(conn)[:callback_path]
 

--- a/test/support/simple_provider_with_state.ex
+++ b/test/support/simple_provider_with_state.ex
@@ -1,0 +1,28 @@
+defmodule Support.SimpleProviderWithState do
+  @moduledoc false
+
+  use Ueberauth.Strategy, ignores_csrf_attack: true
+
+  def uid(%{params: %{"id" => id}} = _conn), do: id
+
+  def credentials(%{params: %{"code" => code}} = conn) do
+    prefix = options(conn)[:token_prefix]
+
+    %Ueberauth.Auth.Credentials{
+      token: "#{prefix}#{code}"
+    }
+  end
+
+  def handle_request!(conn) do
+    callback = options(conn)[:callback_path]
+
+    encoded_params =
+      [code: uid(conn)]
+      |> with_state_param(conn)
+      |> Enum.into(%{})
+      |> URI.encode_query()
+
+    conn
+    |> redirect!("#{callback}?#{encoded_params}")
+  end
+end

--- a/test/ueberauth_test.exs
+++ b/test/ueberauth_test.exs
@@ -11,7 +11,6 @@ defmodule UeberauthTest do
                      key: "_hello_key",
                      signing_salt: "CXlmrshG"
                    )
-  @json_library Ueberauth.json_library()
 
   test "simple request phase" do
     conn = conn(:get, "/auth/simple")
@@ -258,7 +257,7 @@ defmodule UeberauthTest do
 
     assert "/oauth/simple-provider/callback?" <> query_string = location
 
-    assert URI.decode_query(query_string)["state"] |> @json_library.decode!() == %{
+    assert URI.decode_query(query_string)["state"] |> Ueberauth.json_library().decode!() == %{
              "data" => %{"custom" => "data"}
            }
   end
@@ -345,7 +344,8 @@ defmodule UeberauthTest do
         id: "foo",
         code: code,
         state:
-          %{csrf: conn.private[:ueberauth_anti_csrf_token_state_param]} |> @json_library.encode!()
+          %{csrf: conn.private[:ueberauth_anti_csrf_token_state_param]}
+          |> Ueberauth.json_library().encode!()
       )
       |> Map.put(:cookies, conn.cookies)
       |> Map.put(:req_cookies, conn.req_cookies)


### PR DESCRIPTION
Related to #149 

**Motivation**
We need the ability to pass some custom data through the `state`. Currently it's not possible because of the anti CSRF token which was introduced in PR #136 and uses the whole `state`.

**Feature**
I split the `state` into JSON encoded map which contains CSRF token and custom `data` field.
Custom data could be assigned in `request phase` using `Ueberauth.Strategy.Helpers.add_state_param/2`.
Then in `callback phase` you could call `Ueberauth.Strategy.Helpers.get_state_param/1` to read the data.
All of that with maintaining anti CSRF functionality. 