### PR TITLE
Update :csrf_attack to "csrf_attack"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.10.2 - 2022-08-11
+
+- Replace `:csrf_attack` with `"csrf_attack"` so it matches the type specs in `Ueberauth.Failure.Error` [#169](https://github.com/ueberauth/ueberauth/pull/169)
+
 ## 0.10.1 - 2022-07-05
 
 - Fix callback URL not mounted right when router has nested paths [#166](https://github.com/ueberauth/ueberauth/pull/166)

--- a/lib/ueberauth/strategy.ex
+++ b/lib/ueberauth/strategy.ex
@@ -360,7 +360,7 @@ defmodule Ueberauth.Strategy do
   defp add_state_mismatch_error(conn, strategy) do
     conn
     |> Helpers.set_errors!([
-      %Error{message_key: :csrf_attack, message: "Cross-Site Request Forgery attack"}
+      %Error{message_key: "csrf_attack", message: "Cross-Site Request Forgery attack"}
     ])
     |> run_handle_cleanup(strategy)
   end

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Ueberauth.Mixfile do
   use Mix.Project
 
   @source_url "https://github.com/ueberauth/ueberauth"
-  @version "0.10.1"
+  @version "0.10.2"
 
   def project do
     [

--- a/test/ueberauth_test.exs
+++ b/test/ueberauth_test.exs
@@ -303,7 +303,7 @@ defmodule UeberauthTest do
       )
 
     assert conn.assigns.ueberauth_failure != nil
-    assert List.first(conn.assigns.ueberauth_failure.errors).message_key == :csrf_attack
+    assert List.first(conn.assigns.ueberauth_failure.errors).message_key == "csrf_attack"
   end
 
   test "make ensure run_callback properly clean the internal state param in cookie" do


### PR DESCRIPTION
The `Ueberauth.Failure.Error` struct defines a type specification that
says that the `message_key` field should be a binary, however in the case of
CSRF attacks the `Ueberauth.Strategy` sets the error's `message_key` to
`:csrf_attack`. Whilst this does not cause problems in the way this
library works, it causes discrepancies in the way client code has to
handle errors. Ueberauth extensions such as `Ueberauth.Google` follow
the correct type specification and use binaries for `message_key`, so
client code needs to be able to pattern match against different types
which is not ideal.