### PR TITLE
Use or strip port from forwarded host header

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         uses: erlef/setup-beam@v1
         with:
           elixir-version: '1.11'
-          otp-version: '22.3'
+          otp-version: '24.2'
 
       - name: Install Dependencies
         run: |
@@ -37,7 +37,7 @@ jobs:
         uses: erlef/setup-beam@v1
         with:
           elixir-version: '1.11'
-          otp-version: '22.3'
+          otp-version: '24.2'
 
       - name: Install Dependencies
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.10.4 - 2023-01-19
+
+- Fix `port` being duplicate when behind reverse proxy and non-standard port [#103](https://github.com/ueberauth/ueberauth/pull/175)
+
 ## 0.10.3 - 2022-09-13
 
 - Fix `@spec` for `Ueberauth.Strategy.Helpers.set_errors!/2`

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Ueberauth.Mixfile do
   use Mix.Project
 
   @source_url "https://github.com/ueberauth/ueberauth"
-  @version "0.10.3"
+  @version "0.10.4"
 
   def project do
     [

--- a/test/ueberauth_test.exs
+++ b/test/ueberauth_test.exs
@@ -191,6 +191,20 @@ defmodule UeberauthTest do
              "http://changelog.com/auth/provider/callback"
   end
 
+  test "callback_url uses forwarded host with custom port" do
+    conn = %{
+      (conn(:get, "/")
+       |> put_req_header("x-forwarded-host", "changelog.com:8088"))
+      | scheme: :http,
+        port: 80
+    }
+
+    conn = put_private(conn, :ueberauth_request_options, callback_path: "/auth/provider/callback")
+
+    assert Ueberauth.Strategy.Helpers.callback_url(conn) ==
+             "http://changelog.com:8088/auth/provider/callback"
+  end
+
   test "callback_url has custom scheme" do
     conn = %{
       conn(:get, "/")
@@ -213,6 +227,24 @@ defmodule UeberauthTest do
       conn(:get, "/")
       | scheme: :http,
         port: 80
+    }
+
+    conn =
+      put_private(conn, :ueberauth_request_options,
+        callback_path: "/auth/provider/callback",
+        callback_port: 4000
+      )
+
+    assert Ueberauth.Strategy.Helpers.callback_url(conn) ==
+             "http://www.example.com:4000/auth/provider/callback"
+  end
+
+  test "callback_url uses custom port even when forwarded hosts conflicts" do
+    conn = %{
+      (conn(:get, "/")
+       |> put_req_header("x-forwarded-host", "www.example.com:8088"))
+      | scheme: :http,
+        port: 8088
     }
 
     conn =


### PR DESCRIPTION
## Problem

When a Phoenix web app is behind a reverse proxy, the redirect URL may come from the `X-Forwarded-Host` header. While ueberauth does this correctly, it only works on standard ports (80 and 443) and fails if e.g. using a localhost proxy on a non-standard port.

## Steps to Reproduce

Set up Caddy or a reverse proxy of your choice that listens on a non-standard port, e.g. 8080

Configure Phoenix via `dev.exs` to serve from port 4000, but to know that the real site is port 8080.

When a redirect is done (e.g. via Google oauth), the `X-Forwarded-Host` will be `"localhost:8080"`
  * note the port number in the host header, which is legal per the [MDN definition of host](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Host)
  * but the `port` value in `helpers.ex` will *also* be set to `8080`

This results in
```elixir
%URI{host: "localhost:8080", port: 8080}
```

When `.to_string()` is called, the result is `"//[localhost:8080]:8080"`, which will not work.

## Solution

This MR examines the `X-Forwarded-Host` header for whether it contains a `:` and prefers the port number reported there vs. any other config except the override that can be given via `callback_port`. (This change makes using `callback_port` more optional, since it will do the expected thing more often.)

Fixes #103 