### PR TITLE
Handle default ports when the host header has no port specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.10.5 - 2023-03-09
+
+- Fix default port selection when none is specified on the host header [#181](https://github.com/ueberauth/ueberauth/pull/181)
+
 ## 0.10.4 - 2023-01-19
 
 - Fix `port` being duplicate when behind reverse proxy and non-standard port [#103](https://github.com/ueberauth/ueberauth/pull/175)

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Ueberauth.Mixfile do
   use Mix.Project
 
   @source_url "https://github.com/ueberauth/ueberauth"
-  @version "0.10.4"
+  @version "0.10.5"
 
   def project do
     [

--- a/test/ueberauth_test.exs
+++ b/test/ueberauth_test.exs
@@ -191,6 +191,48 @@ defmodule UeberauthTest do
              "http://changelog.com/auth/provider/callback"
   end
 
+  test "callback_url defaults to port 443 for https scheme" do
+    conn = %{
+      conn(:get, "/")
+      | scheme: :https,
+        host: "changelog.com",
+        port: 80
+    }
+
+    conn = put_private(conn, :ueberauth_request_options, callback_path: "/auth/provider/callback")
+
+    assert Ueberauth.Strategy.Helpers.callback_url(conn) ==
+             "https://changelog.com/auth/provider/callback"
+  end
+
+  test "callback_url defaults to port 80 for http scheme" do
+    conn = %{
+      conn(:get, "/")
+      | scheme: :http,
+        host: "changelog.com",
+        port: 200
+    }
+
+    conn = put_private(conn, :ueberauth_request_options, callback_path: "/auth/provider/callback")
+
+    assert Ueberauth.Strategy.Helpers.callback_url(conn) ==
+             "http://changelog.com/auth/provider/callback"
+  end
+
+  test "callback_url uses host port when specified" do
+    conn = %{
+      conn(:get, "/")
+      | scheme: :http,
+        host: "changelog.com:3333",
+        port: 200
+    }
+
+    conn = put_private(conn, :ueberauth_request_options, callback_path: "/auth/provider/callback")
+
+    assert Ueberauth.Strategy.Helpers.callback_url(conn) ==
+             "http://changelog.com:3333/auth/provider/callback"
+  end
+
   test "callback_url uses forwarded host with custom port" do
     conn = %{
       (conn(:get, "/")


### PR DESCRIPTION
Cowboy will automatically default to port 80 when no port has been given, but Bandit does not. Bandit will always default to the underlying port, which makes it hard to know if there was a port specified or if a port was assumed.

This change ignores cowboy or bandit's assumption around port number and parses it from the header directly.

This solves: https://github.com/ueberauth/ueberauth/issues/180
