### PR TITLE
add nil as return type for helper functions using from_private

### DIFF
--- a/lib/ueberauth/strategies/helpers.ex
+++ b/lib/ueberauth/strategies/helpers.ex
@@ -15,13 +15,13 @@ defmodule Ueberauth.Strategy.Helpers do
 
   This is defined in your configuration as the provider name.
   """
-  @spec strategy_name(Plug.Conn.t()) :: String.t()
+  @spec strategy_name(Plug.Conn.t()) :: String.t() | nil
   def strategy_name(conn), do: from_private(conn, :strategy_name)
 
   @doc """
   The strategy module that is being used for the request.
   """
-  @spec strategy(Plug.Conn.t()) :: module
+  @spec strategy(Plug.Conn.t()) :: module | nil
   def strategy(conn), do: from_private(conn, :strategy)
 
   @doc """
@@ -29,7 +29,7 @@ defmodule Ueberauth.Strategy.Helpers do
 
   Requests to this path will trigger the `request_phase` of the strategy.
   """
-  @spec request_path(Plug.Conn.t()) :: String.t()
+  @spec request_path(Plug.Conn.t()) :: String.t() | nil
   def request_path(conn), do: from_private(conn, :request_path)
 
   @doc """
@@ -37,7 +37,7 @@ defmodule Ueberauth.Strategy.Helpers do
 
   When a client hits this path, the callback phase will be triggered for the strategy.
   """
-  @spec callback_path(Plug.Conn.t()) :: String.t()
+  @spec callback_path(Plug.Conn.t()) :: String.t() | nil
   def callback_path(conn), do: from_private(conn, :callback_path)
 
   @doc """
@@ -102,7 +102,7 @@ defmodule Ueberauth.Strategy.Helpers do
   This will use any supplied options from the configuration, but fallback to the
   default options
   """
-  @spec allowed_callback_methods(Plug.Conn.t()) :: list(String.t())
+  @spec allowed_callback_methods(Plug.Conn.t()) :: list(String.t()) | nil
   def allowed_callback_methods(conn), do: from_private(conn, :callback_methods)
 
   @doc """
@@ -123,7 +123,7 @@ defmodule Ueberauth.Strategy.Helpers do
   @doc """
   The full list of options passed to the strategy in the configuration.
   """
-  @spec options(Plug.Conn.t()) :: Keyword.t()
+  @spec options(Plug.Conn.t()) :: Keyword.t() | nil
   def options(conn), do: from_private(conn, :options)
 
   @doc """


### PR DESCRIPTION
add nil as a valid return type for helper functions using from_private, as from_private returns a nil value for missing keys