### PR TITLE
Fix typespec for Helpers.options/1

### DIFF
--- a/lib/ueberauth/strategies/helpers.ex
+++ b/lib/ueberauth/strategies/helpers.ex
@@ -123,7 +123,7 @@ defmodule Ueberauth.Strategy.Helpers do
   @doc """
   The full list of options passed to the strategy in the configuration.
   """
-  @spec options(Plug.Conn.t()) :: Keyword.t()
+  @spec options(Plug.Conn.t()) :: Keyword.t() | nil
   def options(conn), do: from_private(conn, :options)
 
   @doc """


### PR DESCRIPTION
The function from_private/2 can either return a value or nil. The
issue was found when doing a conditional check on the result of the
options function in ueberauth_cognito:

    if opts = options(conn) do
      Keyword.get(opts, :otp_app, default_app)
    else
      default_app
    end

saying that it can never return nil, which is incorrect: 

```elixir
  defp from_private(conn, key) do
    opts = conn.private[:ueberauth_request_options]
    if opts, do: opts[key], else: nil
  end
  ```