### PR TITLE
Update `source_ref`

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -50,6 +50,7 @@ defmodule Ueberauth.Mixfile do
       extras: ["CHANGELOG.md", "README.md", "CONTRIBUTING.md"],
       main: "readme",
       source_url: @source_url,
+      source_ref: "master",
       homepage_url: @source_url,
       formatters: ["html"]
     ]


### PR DESCRIPTION
ExDocs source ref defaults to `main` if not passed, which breaks all source links for Ueberauth, which uses `master` as default branch. This sets the source ref to `master` for documentation.